### PR TITLE
Updated schema to have semantic arguments for events.

### DIFF
--- a/db/game.py
+++ b/db/game.py
@@ -86,7 +86,21 @@ class Events(Model):
     # variable number of fields depending on type of event
     # can be token or string for announcement
     # now make the field
+    # Note that it's typically easier to just use entity1, action, and entity2 instead of arguments.
+    # This field will remain for legacy reasons.
     arguments = fields.JSONField() # list of arguments
+
+    # The first entity involved in the action, typically the one performing the action.
+    # Can be empty in some cases, for example global events such as "* Mission Start *".
+    entity1 = fields.CharField(50)
+
+    # The action being performed by the entity (or the global event, such as "* Mission Start *").
+    action = fields.CharField(50)
+
+    # The second entity involved in the action, typically the entity that something is being done to.
+    # This can be empty if the action doesn't involve a specific recipient, for example if the main entity
+    # activates a nuke.
+    entity2 = fields.CharField(50)
 
     async def to_dict(self) -> dict:
         final = {}

--- a/db/game.py
+++ b/db/game.py
@@ -92,15 +92,15 @@ class Events(Model):
 
     # The first entity involved in the action, typically the one performing the action.
     # Can be empty in some cases, for example global events such as "* Mission Start *".
-    entity1 = fields.CharField(50)
+    entity1 = fields.CharField(50, default="")
 
     # The action being performed by the entity (or the global event, such as "* Mission Start *").
-    action = fields.CharField(50)
+    action = fields.CharField(50, default="")
 
     # The second entity involved in the action, typically the entity that something is being done to.
     # This can be empty if the action doesn't involve a specific recipient, for example if the main entity
     # activates a nuke.
-    entity2 = fields.CharField(50)
+    entity2 = fields.CharField(50, default="")
 
     async def to_dict(self) -> dict:
         final = {}

--- a/db/migrations/models/1_20240318211224_update.py
+++ b/db/migrations/models/1_20240318211224_update.py
@@ -1,0 +1,17 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE `entitystarts` MODIFY COLUMN `role` SMALLINT NOT NULL  COMMENT 'OTHER: 0\nCOMMANDER: 1\nHEAVY: 2\nSCOUT: 3\nAMMO: 4\nMEDIC: 5';
+        ALTER TABLE `events` ADD `entity1` VARCHAR(50) NOT NULL;
+        ALTER TABLE `events` ADD `action` VARCHAR(50) NOT NULL;
+        ALTER TABLE `events` ADD `entity2` VARCHAR(50) NOT NULL;"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE `events` DROP COLUMN `entity1`;
+        ALTER TABLE `events` DROP COLUMN `action`;
+        ALTER TABLE `events` DROP COLUMN `entity2`;
+        ALTER TABLE `entitystarts` MODIFY COLUMN `role` SMALLINT NOT NULL  COMMENT 'BASE: 0\nCOMMANDER: 1\nHEAVY: 2\nSCOUT: 3\nAMMO: 4\nMEDIC: 5';"""

--- a/db/migrations/models/2_20240318215426_update.py
+++ b/db/migrations/models/2_20240318215426_update.py
@@ -1,0 +1,15 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE `events` ALTER COLUMN `action` SET DEFAULT '';
+        ALTER TABLE `events` ALTER COLUMN `entity2` SET DEFAULT '';
+        ALTER TABLE `events` ALTER COLUMN `entity1` SET DEFAULT '';"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE `events` ALTER COLUMN `action` DROP DEFAULT;
+        ALTER TABLE `events` ALTER COLUMN `entity2` DROP DEFAULT;
+        ALTER TABLE `events` ALTER COLUMN `entity1` DROP DEFAULT;"""


### PR DESCRIPTION
All known events have 1-3 arguments. We'll keep the JSON payload so all existing code works, and also in case Laserforce adds a new event type that has more than 3 arguments.

Event parsing is split into two functions, get_arguments_from_event() is a separate function so we can use it to backfill the columns in existing rows.

This change by itself won't change any behavior, it will just add the new columns and populate them in all new events that will be added. They're not used by existing queries yet.