### PR TITLE
Refactored SM5 replay code.

### DIFF
--- a/helpers/replay.py
+++ b/helpers/replay.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+from db.game import Events, Teams, PlayerInfo
+from db.types import EventType, Team
+
 
 def _escape_string(text: str) -> str:
     return text.replace("'", "\\'")
@@ -8,6 +11,7 @@ def _escape_string(text: str) -> str:
 
 @dataclass
 class ReplayCellChange:
+    """Describes a cell in a team table being changed."""
     # Name of the row this update is for.
     row_id: str
 
@@ -22,6 +26,7 @@ class ReplayCellChange:
 
 @dataclass
 class ReplayRowChange:
+    """Describes a row in a team table being changed (typically its CSS class)."""
     # Name of the row this update is for.
     row_id: str
 
@@ -34,6 +39,10 @@ class ReplayRowChange:
 
 @dataclass
 class ReplaySound:
+    """Describes a sound that may be used during a replay.
+
+    One sound may comprise multiple sound assets that are chosen randomly.
+    """
     # List of possible assets to use for this sound.
     asset_urls: List[str]
 
@@ -49,6 +58,7 @@ class ReplaySound:
 
 @dataclass
 class ReplayEvent:
+    """Describes a single event during the replay."""
     # The time at which this event happened.
     timestamp_millis: int
 
@@ -70,6 +80,7 @@ class ReplayEvent:
 
 @dataclass
 class ReplayPlayer:
+    """Describes a player """
     # The innerHTML for each column.
     cells: List[str]
 
@@ -188,3 +199,138 @@ class Replay:
             """
 
         return result
+
+
+@dataclass
+class PlayerState:
+    """Representation of the current state of a player as the replay events are being generated."""
+    row_index: int
+    row_id: str
+    team: Team
+    name: str
+    downed: bool
+
+    def __hash__(self):
+        return self.row_index
+
+
+class ReplayGenerator:
+    """Base class for a gametype-specific replay generator."""
+
+    def __init__(self):
+        self.teams = {}
+        self.team_scores = dict[Team, int]()
+        self.team_sound_balance = dict[Team, float]()
+        self.team_rosters = dict[Team, List[PlayerInfo]]()
+
+        self.entity_id_to_player = dict[str, str]()
+        self.entity_id_to_nonplayer_name = dict[str, str]()
+
+        self.events = []
+        self.cell_changes = []
+        self.row_changes = []
+        self.entity_starts = []
+
+        # Map from a player and the timestamp at which the player will be back up. The key is the _Player object.
+        self.player_reup_times = dict[PlayerState, int]()
+
+        self.sounds = []
+        self.stereo_balance = 0.0
+
+    async def generate(self, game) -> Replay:
+        pass
+
+    def init_teams(self):
+        self.entity_id_to_nonplayer_name = {
+            entity.entity_id: entity.name for entity in self.entity_starts if entity.entity_id[0] == "@"
+        }
+
+    def process_events(self, events: List[Events], event_handler):
+        for event in events:
+            timestamp = event.time
+            old_team_scores = self.team_scores.copy()
+
+            # Before we process the event, let's see if there's a player coming back up. Look up all the timestamps when
+            # someone is coming back up.
+            players_reup_timestamps = [
+                reup_timestamp for reup_timestamp in self.player_reup_times.values() if reup_timestamp < timestamp
+            ]
+
+            if players_reup_timestamps:
+                # Create events for all the players coming back up one by one.
+                players_reup_timestamps.sort()
+
+                row_changes = []
+
+                # Walk through them in order. It's likely that there are multiple players with identical timestamps
+                # (like after a nuke in SM5), so we can't use a dict here.
+                for reup_timestamp in players_reup_timestamps:
+                    # Find the first player with this particular timestamp. There may be multiple after a nuke. But who
+                    # cares. We'll eventually get them one by one.
+                    for player, player_reup_timestamp in self.player_reup_times.items():
+                        if player_reup_timestamp == reup_timestamp:
+                            self.player_reup_times.pop(player)
+                            row_changes.append(ReplayRowChange(player.row_id, player.team.css_class))
+                            player.downed = False
+                            break
+
+                    # Create a dummy event to update the UI.
+                    self.events.append(
+                        ReplayEvent(reup_timestamp, "", cell_changes=[], row_changes=row_changes, team_scores=[],
+                                    sounds=[]))
+
+            # Translate the arguments of the event into HTML if they reference entities.
+            message = ""
+
+            # Note that we don't care about players missing.
+            if event.type != EventType.MISS:
+                for argument in event.arguments:
+                    if argument[0] == "@":
+                        message += self.create_entity_reference(argument)
+                    elif argument[0] == '#':
+                        message += self.create_entity_reference(argument)
+                    else:
+                        message += argument
+
+            player1 = None
+            player2 = None
+
+            if event.arguments[0] in self.entity_id_to_player:
+                player1 = self.entity_id_to_player[event.arguments[0]]
+
+            if len(event.arguments) > 2 and event.arguments[2] in self.entity_id_to_player:
+                player2 = self.entity_id_to_player[event.arguments[2]]
+
+            self.row_changes = []
+            self.cell_changes = []
+            self.sounds = []
+
+            self.handle_event(event, player1, player2)
+
+            if self.team_scores == old_team_scores:
+                new_team_scores = []
+            else:
+                new_team_scores = [
+                    self.team_scores[team] for team in self.team_rosters.keys()
+                ]
+
+            replay_event = ReplayEvent(timestamp_millis=timestamp, message=message, cell_changes=self.cell_changes,
+                                       row_changes=self.row_changes, team_scores=new_team_scores, sounds=self.sounds,
+                                       sound_stereo_balance=self.stereo_balance)
+
+            self.events.append(replay_event)
+
+    def add_sound(self, sound, team: Teams):
+        self.sounds.append(sound)
+        self.stereo_balance = self.team_sound_balance[team]
+
+    def handle_event(self, event: Events, player1, player2) -> ReplayEvent:
+        pass
+
+    def create_entity_reference(self, argument: str) -> str:
+        if argument in self.entity_id_to_nonplayer_name:
+            return self.entity_id_to_nonplayer_name[argument]
+
+        player = self.entity_id_to_player[argument]
+        css_class = player.team.css_class
+        return f'<span class="{css_class}">{player.name}</span>'

--- a/helpers/replay_sm5.py
+++ b/helpers/replay_sm5.py
@@ -206,8 +206,8 @@ class ReplayGeneratorSm5(ReplayGenerator):
 
     async def generate(self, game: SM5Game) -> Replay:
         self.entity_starts = await game.entity_starts.all()
-        team_rosters = await get_team_rosters(self.entity_starts,
-                                              await game.entity_ends.all())
+        self.team_rosters = await get_team_rosters(self.entity_starts,
+                                                   await game.entity_ends.all())
 
         # Set up the teams and players.
         column_headers = ["Role", "Codename", "Score", "Lives", "Shots", "Missiles", "Spec", "Accuracy", "K/D"]
@@ -216,7 +216,7 @@ class ReplayGeneratorSm5(ReplayGenerator):
 
         sound_balance = -0.5
 
-        for team, players in team_rosters.items():
+        for team, players in self.team_rosters.items():
             replay_player_list = []
             players_in_team = []
             self.team_scores[team] = 0
@@ -418,9 +418,13 @@ class ReplayGeneratorSm5(ReplayGenerator):
         self._update_kd(player)
 
     def _update_kd(self, player: _Player):
-        kd_ratio = player.times_shot_others / player.times_got_shot if player.times_got_shot > 0 else 0.0
+        kd_str = ''
+
+        if player.times_got_shot > 0:
+            kd_str = "%0.2f" % (player.times_shot_others / player.times_got_shot)
+
         self.cell_changes.append(
-            ReplayCellChange(row_id=player.row_id, column=_KD_COLUMN, new_value="%.02f" % kd_ratio))
+            ReplayCellChange(row_id=player.row_id, column=_KD_COLUMN, new_value=kd_str))
 
     def _add_special_points(self, player: _Player, points_to_add: int):
         player.special_points += points_to_add

--- a/helpers/replay_sm5.py
+++ b/helpers/replay_sm5.py
@@ -1,26 +1,22 @@
 from dataclasses import dataclass
-from typing import List, Dict
+from typing import List
 
+from db.game import Events
 from db.sm5 import SM5Game
 from db.types import IntRole, EventType, Team
 from helpers.gamehelper import get_team_rosters
-from helpers.replay import Replay, ReplayTeam, ReplayPlayer, ReplayEvent, ReplayCellChange, \
-    ReplayRowChange, ReplaySound
+from helpers.replay import Replay, ReplayTeam, ReplayPlayer, ReplayCellChange, \
+    ReplayRowChange, ReplaySound, ReplayGenerator, PlayerState
 from helpers.sm5helper import SM5_ROLE_DETAILS, Sm5RoleDetails
 
 
 @dataclass
-class _Player:
+class _Player(PlayerState):
     lives: int
     shots: int
-    row_index: int
-    row_id: str
     missiles: int
     role: IntRole
     role_details: Sm5RoleDetails
-    team: Team
-    name: str
-    downed: bool = False
     times_got_shot: int = 0
     times_shot_others: int = 0
     rapid_fire: bool = False
@@ -130,199 +126,149 @@ _BOOST_AUDIO = 10
 _AUDIO_PREFIX = "/assets/sm5/audio/"
 
 
+def _create_role_image(role: IntRole) -> str:
+    return f'<img src="/assets/sm5/roles/{str(role).lower()}.png" alt="{role}" width="30" height="30">'
+
+
 @dataclass
 class _Team:
     players: List[_Player]
 
 
-async def create_sm5_replay(game: SM5Game) -> Replay:
-    game_duration = await game.get_actual_game_duration()
-    entity_starts = await game.entity_starts.all()
-    team_rosters = await get_team_rosters(entity_starts,
-                                          await game.entity_ends.all())
+class ReplayGeneratorSm5(ReplayGenerator):
+    def __init__(self):
+        super().__init__()
 
-    # Set up the teams and players.
-    column_headers = ["Role", "Codename", "Score", "Lives", "Shots", "Missiles", "Spec", "Accuracy", "K/D"]
-    replay_teams = []
-    entity_id_to_player = {}
-    row_index = 1
+        self.team_players_alive = dict[Team, int]()
+        self.start_audio = ReplaySound(
+            [f"{_AUDIO_PREFIX}Start.0.wav", f"{_AUDIO_PREFIX}Start.1.wav", f"{_AUDIO_PREFIX}Start.2.wav",
+             f"{_AUDIO_PREFIX}Start.3.wav"], _START_AUDIO, priority=2, required=True)
+        self.alarm_start_audio = ReplaySound([f"{_AUDIO_PREFIX}Effect/General Quarters.wav"], _ALARM_START_AUDIO,
+                                             priority=1)
+        self.resupply_audio = ReplaySound(
+            [f"{_AUDIO_PREFIX}Effect/Resupply.0.wav", f"{_AUDIO_PREFIX}Effect/Resupply.1.wav",
+             f"{_AUDIO_PREFIX}Effect/Resupply.2.wav", f"{_AUDIO_PREFIX}Effect/Resupply.3.wav",
+             f"{_AUDIO_PREFIX}Effect/Resupply.4.wav"], _RESUPPLY_AUDIO)
+        self.downed_audio = ReplaySound([f"{_AUDIO_PREFIX}Effect/Scream.0.wav", f"{_AUDIO_PREFIX}Effect/Scream.1.wav",
+                                         f"{_AUDIO_PREFIX}Effect/Scream.2.wav", f"{_AUDIO_PREFIX}Effect/Shot.0.wav",
+                                         f"{_AUDIO_PREFIX}Effect/Shot.1.wav"], _DOWNED_AUDIO)
+        self.base_destroyed_audio = ReplaySound([f"{_AUDIO_PREFIX}Effect/Boom.wav"], _BASE_DESTROYED_AUDIO)
+        self.rapid_fire_audio = ReplaySound([
+            f"{_AUDIO_PREFIX}Rapid Fire.0.wav",
+            f"{_AUDIO_PREFIX}Rapid Fire.1.wav",
+            f"{_AUDIO_PREFIX}Rapid Fire.2.wav",
+            f"{_AUDIO_PREFIX}Rapid Fire.3.wav",
+        ],
+            _RAPID_FIRE_AUDIO)
+        self.missile_audio = ReplaySound([
+            f"{_AUDIO_PREFIX}Missile.0.wav",
+            f"{_AUDIO_PREFIX}Missile.1.wav",
+            f"{_AUDIO_PREFIX}Missile.2.wav",
+        ],
+            _MISSILE_AUDIO)
+        self.zap_own_audio = ReplaySound([
+            f"{_AUDIO_PREFIX}Zap Own.0.wav",
+            f"{_AUDIO_PREFIX}Zap Own.1.wav",
+            f"{_AUDIO_PREFIX}Zap Own.2.wav",
+            f"{_AUDIO_PREFIX}Zap Own.3.wav",
+        ],
+            _ZAP_OWN_AUDIO)
+        self.nuke_audio = ReplaySound([
+            f"{_AUDIO_PREFIX}Nuke.0.wav",
+            f"{_AUDIO_PREFIX}Nuke.1.wav",
+            f"{_AUDIO_PREFIX}Nuke.2.wav",
+        ],
+            _NUKE_AUDIO)
+        self.elimination_audio = ReplaySound([
+            f"{_AUDIO_PREFIX}Elimination.wav",
+        ],
+            _ELIMINATION_AUDIO)
+        self.boost_audio = ReplaySound([
+            f"{_AUDIO_PREFIX}Boost.0.wav",
+            f"{_AUDIO_PREFIX}Boost.1.wav",
+            f"{_AUDIO_PREFIX}Boost.2.wav",
+        ],
+            _BOOST_AUDIO)
 
-    teams = {}
-    team_scores = {}
-    team_sound_balance = {}
-    team_players_alive = {}
-
-    entity_id_to_nonplayer_name = {
-        entity.entity_id: entity.name for entity in entity_starts if entity.entity_id[0] == "@"
-    }
-
-    sound_balance = -0.5
-
-    for team, players in team_rosters.items():
-        replay_player_list = []
-        players_in_team = []
-        team_scores[team] = 0
-        team_sound_balance[team] = sound_balance
-        sound_balance += 1.0
-
-        if sound_balance > 1.0:
-            sound_balance -= 2.0
-
-        for player_info in players:
-            if player_info.entity_start.role not in SM5_ROLE_DETAILS:
-                # Shouldn't happen - a player with an unknown SM5 role?
-                continue
-
-            role = player_info.entity_start.role
-            role_details = SM5_ROLE_DETAILS[role]
-
-            cells = [_create_role_image(player_info.entity_start.role), player_info.display_name, "0",
-                     str(role_details.initial_lives), "0", str(role_details.missiles), "0", "", ""]
-            row_id = f"r{row_index}"
-
-            player = _Player(lives=role_details.initial_lives, shots=role_details.shots, row_index=row_index,
-                             role=role, row_id=row_id, missiles=role_details.missiles,
-                             role_details=role_details, team=team, name=player_info.display_name)
-
-            replay_player_list.append(ReplayPlayer(cells=cells, row_id=row_id, css_class=player.team.css_class))
-            row_index += 1
-
-            entity_id_to_player[player_info.entity_start.entity_id] = player
-            players_in_team.append(player)
-
-        replay_team = ReplayTeam(name=team.name, css_class=team.css_class, id=f"{team.element.lower()}_team",
-                                 players=replay_player_list)
-        replay_teams.append(replay_team)
-        teams[team] = players_in_team
-        team_players_alive[team] = len(players_in_team)
-
-    events = []
-
-    # Map from a player and the timestamp at which the player will be back up. The key is the _Player object.
-    player_reup_times = {}
-
-    start_audio = ReplaySound(
-        [f"{_AUDIO_PREFIX}Start.0.wav", f"{_AUDIO_PREFIX}Start.1.wav", f"{_AUDIO_PREFIX}Start.2.wav",
-         f"{_AUDIO_PREFIX}Start.3.wav"], _START_AUDIO, priority=2, required=True)
-    alarm_start_audio = ReplaySound([f"{_AUDIO_PREFIX}Effect/General Quarters.wav"], _ALARM_START_AUDIO, priority=1)
-    resupply_audio = ReplaySound([f"{_AUDIO_PREFIX}Effect/Resupply.0.wav", f"{_AUDIO_PREFIX}Effect/Resupply.1.wav",
-                                  f"{_AUDIO_PREFIX}Effect/Resupply.2.wav", f"{_AUDIO_PREFIX}Effect/Resupply.3.wav",
-                                  f"{_AUDIO_PREFIX}Effect/Resupply.4.wav"], _RESUPPLY_AUDIO)
-    downed_audio = ReplaySound([f"{_AUDIO_PREFIX}Effect/Scream.0.wav", f"{_AUDIO_PREFIX}Effect/Scream.1.wav",
-                                f"{_AUDIO_PREFIX}Effect/Scream.2.wav", f"{_AUDIO_PREFIX}Effect/Shot.0.wav",
-                                f"{_AUDIO_PREFIX}Effect/Shot.1.wav"], _DOWNED_AUDIO)
-    base_destroyed_audio = ReplaySound([f"{_AUDIO_PREFIX}Effect/Boom.wav"], _BASE_DESTROYED_AUDIO)
-    rapid_fire_audio = ReplaySound([
-        f"{_AUDIO_PREFIX}Rapid Fire.0.wav",
-        f"{_AUDIO_PREFIX}Rapid Fire.1.wav",
-        f"{_AUDIO_PREFIX}Rapid Fire.2.wav",
-        f"{_AUDIO_PREFIX}Rapid Fire.3.wav",
-    ],
-        _RAPID_FIRE_AUDIO)
-    missile_audio = ReplaySound([
-        f"{_AUDIO_PREFIX}Missile.0.wav",
-        f"{_AUDIO_PREFIX}Missile.1.wav",
-        f"{_AUDIO_PREFIX}Missile.2.wav",
-    ],
-        _MISSILE_AUDIO)
-    zap_own_audio = ReplaySound([
-        f"{_AUDIO_PREFIX}Zap Own.0.wav",
-        f"{_AUDIO_PREFIX}Zap Own.1.wav",
-        f"{_AUDIO_PREFIX}Zap Own.2.wav",
-        f"{_AUDIO_PREFIX}Zap Own.3.wav",
-    ],
-        _ZAP_OWN_AUDIO)
-    nuke_audio = ReplaySound([
-        f"{_AUDIO_PREFIX}Nuke.0.wav",
-        f"{_AUDIO_PREFIX}Nuke.1.wav",
-        f"{_AUDIO_PREFIX}Nuke.2.wav",
-    ],
-        _NUKE_AUDIO)
-    elimination_audio = ReplaySound([
-        f"{_AUDIO_PREFIX}Elimination.wav",
-    ],
-        _ELIMINATION_AUDIO)
-    boost_audio = ReplaySound([
-        f"{_AUDIO_PREFIX}Boost.0.wav",
-        f"{_AUDIO_PREFIX}Boost.1.wav",
-        f"{_AUDIO_PREFIX}Boost.2.wav",
-    ],
-        _BOOST_AUDIO)
-
-    sound_assets = [
-        start_audio,
-        alarm_start_audio,
-        resupply_audio,
-        downed_audio,
-        base_destroyed_audio,
-        rapid_fire_audio,
-        missile_audio,
-        zap_own_audio,
-        nuke_audio,
-        elimination_audio,
-        boost_audio,
-    ]
-
-    # Now let's walk through the events one by one and translate them into UI events.
-    for event in await game.events.all():
-
-        timestamp = event.time
-        old_team_scores = team_scores.copy()
-        sounds = []
-        stereo_balance = 0.0
-
-        # Before we process the event, let's see if there's a player coming back up. Look up all the timestamps when
-        # someone is coming back up.
-        players_reup_timestamps = [
-            reup_timestamp for reup_timestamp in player_reup_times.values() if reup_timestamp < timestamp
+        self.sound_assets = [
+            self.start_audio,
+            self.alarm_start_audio,
+            self.resupply_audio,
+            self.downed_audio,
+            self.base_destroyed_audio,
+            self.rapid_fire_audio,
+            self.missile_audio,
+            self.zap_own_audio,
+            self.nuke_audio,
+            self.elimination_audio,
+            self.boost_audio,
         ]
 
-        if players_reup_timestamps:
-            # Create events for all the players coming back up one by one.
-            players_reup_timestamps.sort()
+    async def generate(self, game: SM5Game) -> Replay:
+        self.entity_starts = await game.entity_starts.all()
+        team_rosters = await get_team_rosters(self.entity_starts,
+                                              await game.entity_ends.all())
 
-            row_changes = []
+        # Set up the teams and players.
+        column_headers = ["Role", "Codename", "Score", "Lives", "Shots", "Missiles", "Spec", "Accuracy", "K/D"]
+        replay_teams = []
+        row_index = 1
 
-            # Walk through them in order. It's likely that there are multiple players with identical timestamps (usually
-            # after a nuke), so we can't use a dict here.
-            for reup_timestamp in players_reup_timestamps:
-                # Find the first player with this particular timestamp. There may be multiple after a nuke. But who
-                # cares. We'll eventually get them one by one.
-                for player, player_reup_timestamp in player_reup_times.items():
-                    if player_reup_timestamp == reup_timestamp:
-                        player_reup_times.pop(player)
-                        row_changes.append(ReplayRowChange(player.row_id, player.team.css_class))
-                        player.downed = False
-                        break
+        sound_balance = -0.5
 
-                # Create a dummy event to update the UI.
-                events.append(ReplayEvent(reup_timestamp, "", cell_changes=[], row_changes=row_changes, team_scores=[],
-                                          sounds=[]))
+        for team, players in team_rosters.items():
+            replay_player_list = []
+            players_in_team = []
+            self.team_scores[team] = 0
+            self.team_sound_balance[team] = sound_balance
+            sound_balance += 1.0
 
-        # Translate the arguments of the event into HTML if they reference entities.
-        message = ""
+            if sound_balance > 1.0:
+                sound_balance -= 2.0
 
-        # Note that we don't care about players missing.
-        if event.type != EventType.MISS:
-            for argument in event.arguments:
-                if argument[0] == "@":
-                    message += _create_entity_reference(argument, entity_id_to_player, entity_id_to_nonplayer_name)
-                elif argument[0] == '#':
-                    message += _create_entity_reference(argument, entity_id_to_player, entity_id_to_nonplayer_name)
-                else:
-                    message += argument
+            for player_info in players:
+                if player_info.entity_start.role not in SM5_ROLE_DETAILS:
+                    # Shouldn't happen - a player with an unknown SM5 role?
+                    continue
 
-        cell_changes = []
-        row_changes = []
-        player1 = None
-        player2 = None
+                role = player_info.entity_start.role
+                role_details = SM5_ROLE_DETAILS[role]
 
-        if event.arguments[0] in entity_id_to_player:
-            player1 = entity_id_to_player[event.arguments[0]]
+                cells = [_create_role_image(player_info.entity_start.role), player_info.display_name, "0",
+                         str(role_details.initial_lives), "0", str(role_details.missiles), "0", "", ""]
+                row_id = f"r{row_index}"
 
-        if len(event.arguments) > 2 and event.arguments[2] in entity_id_to_player:
-            player2 = entity_id_to_player[event.arguments[2]]
+                player = _Player(lives=role_details.initial_lives, shots=role_details.shots, row_index=row_index,
+                                 role=role, row_id=row_id, missiles=role_details.missiles,
+                                 role_details=role_details, team=team, name=player_info.display_name, downed=False)
 
+                replay_player_list.append(ReplayPlayer(cells=cells, row_id=row_id, css_class=player.team.css_class))
+                row_index += 1
+
+                self.entity_id_to_player[player_info.entity_start.entity_id] = player
+                players_in_team.append(player)
+
+            replay_team = ReplayTeam(name=team.name, css_class=team.css_class, id=f"{team.element.lower()}_team",
+                                     players=replay_player_list)
+            replay_teams.append(replay_team)
+            self.teams[team] = players_in_team
+            self.team_players_alive[team] = len(players_in_team)
+
+        self.init_teams()
+
+        self.process_events(await game.events.all(), self.handle_event)
+
+        return Replay(
+            events=self.events,
+            teams=replay_teams,
+            column_headers=column_headers,
+            sounds=self.sound_assets,
+            intro_sound=self.start_audio,
+            start_sound=self.alarm_start_audio,
+            sort_columns_index=[_SCORE_COLUMN]
+        )
+
+    def handle_event(self, event: Events, player1, player2):
         # Count successful hits. Must be done before removing the shot so the accuracy is correct.
         if event.type in _EVENTS_SUCCESSFUL_HITS:
             player1.total_shots_hit += 1
@@ -330,212 +276,169 @@ async def create_sm5_replay(game: SM5Game) -> Replay:
         # Remove a shot if the player just zapped, and update accuracy.
         if event.type in _EVENTS_COSTING_SHOTS:
             if player1.role != IntRole.AMMO:
-                _add_shots(player1, -1, cell_changes)
+                self._add_shots(player1, -1)
 
             player1.total_shots_fired += 1
 
             # Recompute accuracy.
-            cell_changes.append(ReplayCellChange(row_id=player1.row_id, column=_ACCURACY_COLUMN,
-                                                 new_value="%.2f%%" % (
-                                                     player1.total_shots_hit * 100 / player1.total_shots_fired)))
+            self.cell_changes.append(ReplayCellChange(row_id=player1.row_id, column=_ACCURACY_COLUMN,
+                                                      new_value="%.2f%%" % (
+                                                              player1.total_shots_hit * 100 / player1.total_shots_fired)))
 
         # Handle losing lives.
         if event.type in _EVENTS_COSTING_LIVES:
-            _add_lives(player2, -_EVENTS_COSTING_LIVES[event.type], cell_changes, row_changes, player_reup_times)
+            self._add_lives(player2, -_EVENTS_COSTING_LIVES[event.type])
 
         if event.type in _EVENTS_COSTING_MISSILES:
             player1.missiles -= 1
-            cell_changes.append(
+            self.cell_changes.append(
                 ReplayCellChange(row_id=player1.row_id, column=_MISSILES_COLUMN, new_value=str(player1.missiles)))
 
         if event.type in _EVENTS_GIVING_SPECIAL_POINTS:
             # Heavy doesn't get special points, and neither do scouts with rapid fire.
             if player1.role != IntRole.HEAVY and not player1.rapid_fire:
-                _add_special_points(player1, _EVENTS_GIVING_SPECIAL_POINTS[event.type], cell_changes)
+                self._add_special_points(player1, _EVENTS_GIVING_SPECIAL_POINTS[event.type])
 
         if event.type in _EVENTS_ADDING_TO_SCORE:
-            _add_score(player1, _EVENTS_ADDING_TO_SCORE[event.type], cell_changes, team_scores)
+            self._add_score(player1, _EVENTS_ADDING_TO_SCORE[event.type])
 
         # Handle each event.
         match event.type:
             case EventType.RESUPPLY_LIVES:
-                _add_lives(player2, player2.role_details.lives_resupply, cell_changes, row_changes, player_reup_times)
-                sounds.append(resupply_audio)
-                stereo_balance = team_sound_balance[player2.team]
+                self._add_lives(player2, player2.role_details.lives_resupply)
+                self.add_sound(self.resupply_audio, player2.team)
 
             case EventType.RESUPPLY_AMMO:
-                _add_shots(player2, player2.role_details.shots_resupply, cell_changes)
-                sounds.append(resupply_audio)
-                stereo_balance = team_sound_balance[player2.team]
+                self._add_shots(player2, player2.role_details.shots_resupply)
+                self.add_sound(self.resupply_audio, player2.team)
 
             case EventType.ACTIVATE_RAPID_FIRE:
                 player1.rapid_fire = True
-                _add_special_points(player1, -10, cell_changes)
-                stereo_balance = team_sound_balance[player1.team]
-                sounds.append(rapid_fire_audio)
+                self._add_special_points(player1, -10)
+                self.add_sound(self.rapid_fire_audio, player1.team)
 
             case EventType.DESTROY_BASE | EventType.MISISLE_BASE_DESTROY | EventType.MISSILE_BASE_DAMAGE:
-                sounds.append(base_destroyed_audio)
-                stereo_balance = team_sound_balance[player1.team]
+                self.add_sound(self.base_destroyed_audio, player1.team)
 
             case EventType.DAMAGED_OPPONENT | EventType.DOWNED_OPPONENT:
-                _add_score(player2, -20, cell_changes, team_scores)
-                _increase_times_shot_others(player1, cell_changes)
-                _increase_times_got_shot(player2, cell_changes)
-                stereo_balance = team_sound_balance[player2.team]
-                sounds.append(downed_audio)
+                self._add_score(player2, -20)
+                self._increase_times_shot_others(player1)
+                self._increase_times_got_shot(player2)
+                self.add_sound(self.downed_audio, player2.team)
 
             case EventType.DAMANGED_TEAM | EventType.DOWNED_TEAM:
-                _add_score(player2, -20, cell_changes, team_scores)
-                _increase_times_shot_others(player1, cell_changes)
-                _increase_times_got_shot(player2, cell_changes)
-                stereo_balance = team_sound_balance[player2.team]
-                sounds.append(zap_own_audio)
+                self._add_score(player2, -20)
+                self._increase_times_shot_others(player1)
+                self._increase_times_got_shot(player2)
+                self.add_sound(self.zap_own_audio, player2.team)
 
             case EventType.MISSILE_DOWN_OPPONENT | EventType.MISSILE_DAMAGE_OPPONENT | EventType.MISSILE_DOWN_TEAM | EventType.MISSILE_DAMAGE_TEAM:
-                _add_score(player2, -100, cell_changes, team_scores)
-                stereo_balance = team_sound_balance[player2.team]
-                sounds.append(missile_audio)
+                self._add_score(player2, -100)
+                self.add_sound(self.missile_audio, player2.team)
 
             case EventType.DEACTIVATE_RAPID_FIRE:
                 player1.rapid_fire = False
 
             case EventType.ACTIVATE_NUKE:
-                _add_special_points(player1, -20, cell_changes)
-                stereo_balance = team_sound_balance[player1.team]
+                self._add_special_points(player1, -20)
+                self.add_sound(self.nuke_audio, player1.team)
 
             case EventType.DETONATE_NUKE:
-                for team in teams:
+                for team in self.teams:
                     if team != player1.team:
-                        for player in teams[team]:
-                            _add_lives(player, -3, cell_changes, row_changes, player_reup_times)
-                            _down_player(player, row_changes, event.time, player_reup_times)
-
-                stereo_balance = team_sound_balance[player1.team]
-                sounds.append(nuke_audio)
+                        for player in self.teams[team]:
+                            self._add_lives(player, -3)
+                            self._down_player(player, event.time)
 
             case EventType.AMMO_BOOST:
-                for player in teams[player1.team]:
+                for player in self.teams[player1.team]:
                     if not player.downed:
-                        _add_shots(player, player.role_details.shots_resupply, cell_changes)
-                sounds.append(boost_audio)
-                stereo_balance = team_sound_balance[player1.team]
+                        self._add_shots(player, player.role_details.shots_resupply)
+                self.add_sound(self.boost_audio, player1.team)
 
             case EventType.LIFE_BOOST:
-                for player in teams[player1.team]:
+                for player in self.teams[player1.team]:
                     if not player.downed:
-                        _add_lives(player, player.role_details.lives_resupply, cell_changes, row_changes,
-                                   player_reup_times)
-                sounds.append(boost_audio)
-                stereo_balance = team_sound_balance[player1.team]
+                        self._add_lives(player, player.role_details.lives_resupply)
+                self.add_sound(self.boost_audio, player1.team)
 
             case EventType.PENALTY:
-                _add_score(player2, -1000, cell_changes, team_scores)
+                self._add_score(player2, -1000)
 
         # Handle a player being down.
         if event.type in _EVENTS_DOWNING_PLAYER:
-            _down_player(player2, row_changes, event.time, player_reup_times)
+            self._down_player(player2, event.time)
 
-        if team_scores == old_team_scores:
-            new_team_scores = []
-        else:
-            new_team_scores = [
-                team_scores[team] for team in team_rosters.keys()
-            ]
+    def _down_player(self, player: _Player, timestamp_millis: int):
+        if player.lives == 0:
+            return
 
-        events.append(ReplayEvent(timestamp_millis=timestamp, message=message, cell_changes=cell_changes,
-                                  row_changes=row_changes, team_scores=new_team_scores, sounds=sounds,
-                                  sound_stereo_balance=stereo_balance))
+        self.row_changes.append(ReplayRowChange(row_id=player.row_id, new_css_class=player.team.down_css_class))
 
-    return Replay(
-        events=events,
-        teams=replay_teams,
-        column_headers=column_headers,
-        sounds=sound_assets,
-        intro_sound=start_audio,
-        start_sound=alarm_start_audio,
-        sort_columns_index=[_SCORE_COLUMN]
-    )
-
-
-def _down_player(player: _Player, row_changes: List[ReplayRowChange], timestamp_millis: int,
-                 player_reup_times: Dict[_Player, int]):
-    if player.lives == 0:
-        return
-
-    row_changes.append(ReplayRowChange(row_id=player.row_id, new_css_class=player.team.down_css_class))
-
-    # The player will be back up 8 seconds from now.
-    player_reup_times[player] = timestamp_millis + 8000
-    player.rapid_fire = False
-    player.downed = True
-
-
-def _add_lives(player: _Player, lives_to_add: int, cell_changes: List[ReplayCellChange],
-               row_changes: List[ReplayRowChange], player_reup_times: Dict[_Player, int]):
-    previous_lives = player.lives
-
-    player.lives = max(min(player.lives + lives_to_add, player.role_details.lives_max), 0)
-
-    cell_changes.append(ReplayCellChange(row_id=player.row_id, column=_LIVES_COLUMN, new_value=str(player.lives)))
-
-    if player.lives == 0 and previous_lives > 0:
+        # The player will be back up 8 seconds from now.
+        self.player_reup_times[player] = timestamp_millis + 8000
+        player.rapid_fire = False
         player.downed = True
-        row_changes.append(ReplayRowChange(row_id=player.row_id, new_css_class="eliminated_player"))
 
-        # This player ain't coming back up.
-        if player in player_reup_times:
-            player_reup_times.pop(player)
-        return
+    def _add_lives(self, player: _Player, lives_to_add: int):
+        previous_lives = player.lives
+
+        player.lives = max(min(player.lives + lives_to_add, player.role_details.lives_max), 0)
+
+        self.cell_changes.append(
+            ReplayCellChange(row_id=player.row_id, column=_LIVES_COLUMN, new_value=str(player.lives)))
+
+        if player.lives == 0 and previous_lives > 0:
+            player.downed = True
+            self.row_changes.append(ReplayRowChange(row_id=player.row_id, new_css_class="eliminated_player"))
+
+            self.team_players_alive[player.team] -= 1
+
+            if self.team_players_alive[player.team] == 0:
+                # The entire team has been eliminated.
+                self.add_sound(self.elimination_audio, player.team)
+
+            # This player ain't coming back up.
+            if player in self.player_reup_times:
+                self.player_reup_times.pop(player)
+            return
+
+    def _add_shots(self, player: _Player, shots_to_add: int):
+        player.shots = max(min(player.shots + shots_to_add, player.role_details.shots_max), 0)
+
+        self.cell_changes.append(
+            ReplayCellChange(row_id=player.row_id, column=_SHOTS_COLUMN, new_value=str(player.shots)))
+
+    def _increase_times_shot_others(self, player: _Player):
+        player.times_shot_others += 1
+        self._update_kd(player)
+
+    def _increase_times_got_shot(self, player: _Player):
+        player.times_got_shot += 1
+        self._update_kd(player)
+
+    def _update_kd(self, player: _Player):
+        kd_ratio = player.times_shot_others / player.times_got_shot if player.times_got_shot > 0 else 0.0
+        self.cell_changes.append(
+            ReplayCellChange(row_id=player.row_id, column=_KD_COLUMN, new_value="%.02f" % kd_ratio))
+
+    def _add_special_points(self, player: _Player, points_to_add: int):
+        player.special_points += points_to_add
+
+        # 99 special points are the cap.
+        player.special_points = min(player.special_points, 99)
+
+        self.cell_changes.append(
+            ReplayCellChange(row_id=player.row_id, column=_SPEC_COLUMN, new_value=str(player.special_points)))
+
+    def _add_score(self, player: _Player, points_to_add: int):
+        player.score += points_to_add
+        self.cell_changes.append(
+            ReplayCellChange(row_id=player.row_id, column=_SCORE_COLUMN, new_value=str(player.score)))
+
+        self.team_scores[player.team] += points_to_add
 
 
-def _add_shots(player: _Player, shots_to_add: int, cell_changes: List[ReplayCellChange]):
-    player.shots = max(min(player.shots + shots_to_add, player.role_details.shots_max), 0)
-
-    cell_changes.append(ReplayCellChange(row_id=player.row_id, column=_SHOTS_COLUMN, new_value=str(player.shots)))
-
-
-def _increase_times_shot_others(player: _Player, cell_changes: List[ReplayCellChange]):
-    player.times_shot_others += 1
-    _update_kd(player, cell_changes)
-
-
-def _increase_times_got_shot(player: _Player, cell_changes: List[ReplayCellChange]):
-    player.times_got_shot += 1
-    _update_kd(player, cell_changes)
-
-
-def _update_kd(player: _Player, cell_changes: List[ReplayCellChange]):
-    kd_ratio = player.times_shot_others / player.times_got_shot if player.times_got_shot > 0 else 0.0
-    cell_changes.append(ReplayCellChange(row_id=player.row_id, column=_KD_COLUMN, new_value="%.02f" % kd_ratio))
-
-
-def _add_special_points(player: _Player, points_to_add: int, cell_changes: List[ReplayCellChange]):
-    player.special_points += points_to_add
-
-    # 99 special points are the cap.
-    player.special_points = min(player.special_points, 99)
-
-    cell_changes.append(
-        ReplayCellChange(row_id=player.row_id, column=_SPEC_COLUMN, new_value=str(player.special_points)))
-
-
-def _add_score(player: _Player, points_to_add: int, cell_changes: List[ReplayCellChange], team_scores: Dict[Team, int]):
-    player.score += points_to_add
-    cell_changes.append(
-        ReplayCellChange(row_id=player.row_id, column=_SCORE_COLUMN, new_value=str(player.score)))
-
-    team_scores[player.team] += points_to_add
-
-
-def _create_role_image(role: IntRole) -> str:
-    return f'<img src="/assets/sm5/roles/{str(role).lower()}.png" alt="{role}" width="30" height="30">'
-
-
-def _create_entity_reference(argument: str, entity_id_to_player: dict, entity_id_to_nonplayer_name: dict) -> str:
-    if argument in entity_id_to_nonplayer_name:
-        return entity_id_to_nonplayer_name[argument]
-
-    player = entity_id_to_player[argument]
-    css_class = player.team.css_class
-    return f'<span class="{css_class}">{player.name}</span>'
+async def create_sm5_replay(game: SM5Game) -> Replay:
+    generator = ReplayGeneratorSm5()
+    return await generator.generate(game)

--- a/tests/helpers/environment.py
+++ b/tests/helpers/environment.py
@@ -129,9 +129,11 @@ async def add_sm5_event(event: Events):
     await _TEST_SM5_GAME.events.add(event)
 
 
-async def create_zap_event(time_millis: int, zapping_entity_id: str, zapped_entity_id: str) -> Events:
+async def create_zap_event(time_millis: int, zapping_entity_id: str, zapped_entity_id: str,
+                           opponent_down: bool = True) -> Events:
     return await create_event_from_data(
-        ["4", str(time_millis), EventType.DOWNED_OPPONENT, zapping_entity_id, " zaps ", zapped_entity_id])
+        ["4", str(time_millis), EventType.DOWNED_OPPONENT if opponent_down else EventType.DAMAGED_OPPONENT,
+         zapping_entity_id, " zaps ", zapped_entity_id])
 
 
 async def create_block_event(time_millis: int, blocking_entity_id: str, blocked_entity_id: str) -> Events:

--- a/tests/helpers/replay_sm5_test.py
+++ b/tests/helpers/replay_sm5_test.py
@@ -12,23 +12,24 @@ class TestReplaySm5(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         await setup_test_database(basic_events=False)
 
+        self.game = await SM5Game.filter(id=get_sm5_game_id()).first()
+
+        self.entity1, self.entity_end1 = await add_entity(entity_id="@NotLoggedIn", name="Indy", team=get_red_team(),
+                                                          role=IntRole.COMMANDER, type="player", sm5_game=self.game)
+        self.entity2, self.entity_end2 = await add_entity(entity_id="@NotMember", name="Miles", team=get_green_team(),
+                                                          role=IntRole.SCOUT, type="player", sm5_game=self.game)
+        self.entity3, self.entity_end3 = await add_entity(entity_id="LoggedIn", name="Bumblebee", team=get_red_team(),
+                                                          role=IntRole.MEDIC, type="player", sm5_game=self.game)
+
     async def asyncTearDown(self):
         await teardown_test_database()
 
     async def test_create_sm5_replay(self):
-        game = await SM5Game.filter(id=get_sm5_game_id()).first()
+        await self.game.events.add(await create_zap_event(2000, self.entity1.entity_id, self.entity2.entity_id))
+        await self.game.events.add(
+            await create_resupply_lives_event(2500, self.entity3.entity_id, self.entity1.entity_id))
 
-        entity1, entity_end1 = await add_entity(entity_id="@NotLoggedIn", name="Indy", team=get_red_team(),
-                                                role=IntRole.COMMANDER, type="player", sm5_game=game)
-        entity2, entity_end2 = await add_entity(entity_id="@NotMember", name="Miles", team=get_green_team(),
-                                                role=IntRole.SCOUT, type="player", sm5_game=game)
-        entity3, entity_end3 = await add_entity(entity_id="LoggedIn", name="Bumblebee", team=get_red_team(),
-                                                role=IntRole.MEDIC, type="player", sm5_game=game)
-
-        await game.events.add(await create_zap_event(2000, entity1.entity_id, entity2.entity_id))
-        await game.events.add(await create_resupply_lives_event(2500, entity3.entity_id, entity1.entity_id))
-
-        replay = await create_sm5_replay(game)
+        replay = await create_sm5_replay(self.game)
 
         print(replay)
 
@@ -103,6 +104,138 @@ class TestReplaySm5(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(expected, replay)
 
+    async def test_zap_and_down_opponent(self):
+        await self.game.events.add(await create_zap_event(2000, self.entity1.entity_id, self.entity2.entity_id))
 
-if __name__ == '__main__':
-    unittest.main()
+        replay = await create_sm5_replay(self.game)
+
+        # Commander tagging scout. Scout will go down.
+        expected_events = [ReplayEvent(timestamp_millis=2000, message='Indy zaps Miles', team_scores=[100, -20],
+                                       cell_changes=[ReplayCellChange(row_id='r1', column=4, new_value='29'),
+                                                     # 29 shots
+                                                     ReplayCellChange(row_id='r1', column=7,
+                                                                      new_value='100.00%'),  # 100% accuracy
+                                                     ReplayCellChange(row_id='r3', column=3, new_value='14'),
+                                                     # 14 lives
+                                                     ReplayCellChange(row_id='r1', column=6, new_value='1'),  # 1 spec
+                                                     ReplayCellChange(row_id='r1', column=2, new_value='100'),
+                                                     # 100 pts
+                                                     ReplayCellChange(row_id='r3', column=2, new_value='-20'),
+                                                     # -20 pts
+                                                     ReplayCellChange(row_id='r1', column=8, new_value=''),  # K/D
+                                                     ReplayCellChange(row_id='r3', column=8, new_value='0.00')],  # K/D
+                                       row_changes=[
+                                           ReplayRowChange(row_id='r3', new_css_class='earth-team-down')],
+                                       # player down
+                                       sounds=[ReplaySound(asset_urls=['/assets/sm5/audio/Effect/Scream.0.wav',
+                                                                       '/assets/sm5/audio/Effect/Scream.1.wav',
+                                                                       '/assets/sm5/audio/Effect/Scream.2.wav',
+                                                                       '/assets/sm5/audio/Effect/Shot.0.wav',
+                                                                       '/assets/sm5/audio/Effect/Shot.1.wav'],
+                                                           id=3, priority=0, required=False)],
+                                       sound_stereo_balance=0.5)]
+
+        print(replay)
+
+        self.assertEqual(expected_events, replay.events)
+
+    async def test_downed_player_comes_back_up(self):
+        await self.game.events.add(await create_zap_event(2000, self.entity1.entity_id, self.entity2.entity_id))
+        await self.game.events.add(await create_zap_event(20000, self.entity1.entity_id, self.entity2.entity_id))
+
+        replay = await create_sm5_replay(self.game)
+
+        # Commander tagging scout. Scout will go down. Scout will come back up 8 seconds later (10.000ms in).
+        up_event = ReplayEvent(timestamp_millis=10000, message='', team_scores=[],
+                               cell_changes=[],
+                               row_changes=[
+                                   ReplayRowChange(row_id='r3', new_css_class='earth-team')],
+                               sounds=[],
+                               sound_stereo_balance=0.0)
+
+        self.assertEqual(up_event, replay.events[1])
+
+        # Let's briefly check that the next event has been added as well.
+        self.assertEqual(20000, replay.events[2].timestamp_millis)
+
+    async def test_zap_and_damage_opponent(self):
+        await self.game.events.add(
+            await create_zap_event(2000, self.entity2.entity_id, self.entity1.entity_id, opponent_down=False))
+        await self.game.events.add(
+            await create_zap_event(20000, self.entity2.entity_id, self.entity1.entity_id, opponent_down=False))
+
+        replay = await create_sm5_replay(self.game)
+
+        # Scout zaps commander. Commander won't go down.
+        expected_events = [ReplayEvent(timestamp_millis=2000, message='Miles zaps Indy', team_scores=[-20, 100],
+                                       cell_changes=[ReplayCellChange(row_id='r3',
+                                                                      column=4,
+                                                                      new_value='29'),
+                                                     ReplayCellChange(row_id='r3',
+                                                                      column=7,
+                                                                      new_value='100.00%'),
+                                                     ReplayCellChange(row_id='r3',
+                                                                      column=6,
+                                                                      new_value='1'),
+                                                     ReplayCellChange(row_id='r3',
+                                                                      column=2,
+                                                                      new_value='100'),
+                                                     ReplayCellChange(row_id='r1',
+                                                                      column=2,
+                                                                      new_value='-20'),
+                                                     ReplayCellChange(row_id='r3',
+                                                                      column=8,
+                                                                      new_value=''),
+                                                     ReplayCellChange(row_id='r1',
+                                                                      column=8,
+                                                                      new_value='0.00')],  # K/D
+                                       row_changes=[],
+                                       # player down
+                                       sounds=[ReplaySound(asset_urls=['/assets/sm5/audio/Effect/Scream.0.wav',
+                                                                       '/assets/sm5/audio/Effect/Scream.1.wav',
+                                                                       '/assets/sm5/audio/Effect/Scream.2.wav',
+                                                                       '/assets/sm5/audio/Effect/Shot.0.wav',
+                                                                       '/assets/sm5/audio/Effect/Shot.1.wav'],
+                                                           id=3, priority=0, required=False)],
+                                       sound_stereo_balance=-0.5),
+                           ReplayEvent(timestamp_millis=20000,
+                                       message='Miles zaps Indy',
+                                       team_scores=[-40, 200],
+                                       cell_changes=[ReplayCellChange(row_id='r3',
+                                                                      column=4,
+                                                                      new_value='28'),
+                                                     ReplayCellChange(row_id='r3',
+                                                                      column=7,
+                                                                      new_value='100.00%'),
+                                                     ReplayCellChange(row_id='r3',
+                                                                      column=6,
+                                                                      new_value='2'),
+                                                     ReplayCellChange(row_id='r3',
+                                                                      column=2,
+                                                                      new_value='200'),
+                                                     ReplayCellChange(row_id='r1',
+                                                                      column=2,
+                                                                      new_value='-40'),
+                                                     ReplayCellChange(row_id='r3',
+                                                                      column=8,
+                                                                      new_value=''),
+                                                     ReplayCellChange(row_id='r1',
+                                                                      column=8,
+                                                                      new_value='0.00')],
+                                       row_changes=[],
+                                       sounds=[ReplaySound(asset_urls=['/assets/sm5/audio/Effect/Scream.0.wav',
+                                                                       '/assets/sm5/audio/Effect/Scream.1.wav',
+                                                                       '/assets/sm5/audio/Effect/Scream.2.wav',
+                                                                       '/assets/sm5/audio/Effect/Shot.0.wav',
+                                                                       '/assets/sm5/audio/Effect/Shot.1.wav'],
+                                                           id=3,
+                                                           priority=0,
+                                                           required=False)],
+                                       sound_stereo_balance=-0.5)]
+
+        print(replay)
+
+        self.assertEqual(expected_events, replay.events)
+
+    if __name__ == '__main__':
+        unittest.main()

--- a/tests/helpers/replay_sm5_test.py
+++ b/tests/helpers/replay_sm5_test.py
@@ -237,5 +237,6 @@ class TestReplaySm5(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(expected_events, replay.events)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/helpers/replay_sm5_test.py
+++ b/tests/helpers/replay_sm5_test.py
@@ -237,5 +237,5 @@ class TestReplaySm5(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(expected_events, replay.events)
 
-    if __name__ == '__main__':
-        unittest.main()
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/helpers/replay_sm5_test.py
+++ b/tests/helpers/replay_sm5_test.py
@@ -41,7 +41,7 @@ class TestReplaySm5(unittest.IsolatedAsyncioTestCase):
                                                             ReplayCellChange(row_id='r1', column=6, new_value='1'),
                                                             ReplayCellChange(row_id='r1', column=2, new_value='100'),
                                                             ReplayCellChange(row_id='r3', column=2, new_value='-20'),
-                                                            ReplayCellChange(row_id='r1', column=8, new_value='0.00'),
+                                                            ReplayCellChange(row_id='r1', column=8, new_value=''),
                                                             ReplayCellChange(row_id='r3', column=8, new_value='0.00')],
                                               row_changes=[
                                                   ReplayRowChange(row_id='r3', new_css_class='earth-team-down')],


### PR DESCRIPTION
More common logic into a base class that can also be used by the Laserball replay, and have everything inside a class so we don't have to pass a bunch of arrays around across all the functions. Removed over 100 LOC from the SM5 replay code.
This allows for more persistent state, so we can add the elimination sound.
Also added some more fine-grained tests.