### PR TITLE
Show team size and reason for non-ranking in the games list.

### DIFF
--- a/assets/html/game/games.html
+++ b/assets/html/game/games.html
@@ -47,6 +47,30 @@
         width: 50%;
     }
 
+    .ranked-column {
+        font-size: 1.5rem;
+    }
+
+    .ranked-icon {
+        display: inline-block;
+        min-width: 2em;
+        vertical-align: middle;
+    }
+
+    .ranked-team-size {
+        display: inline-block;
+        min-width: 3em;
+        font-size: 1.0rem;
+        vertical-align: middle;
+    }
+
+    .ranked-reason {
+        display: inline-block;
+        min-width: 8em;
+        font-size: 1.0rem;
+        vertical-align: middle;
+    }
+
     #mode_table {
         width: 25rem;
         margin-bottom: 1.5rem;
@@ -162,9 +186,20 @@
             {% for game in sm5_games %}
                 <tr>
                     <td><a href="/game/sm5/{{game.id}}">{{ game.start_time.strftime("%Y/%m/%d %I:%M %p") }}</a></td>
-                    <td style="color: {{ game.winner.css_color_name }};">{{ game.winner.standardize() }}</td>
+                    <td style="color: {{ game.winner.css_color_name }};">{{ game.winner.standardize() }} {{ '(elim)' if game.last_team_standing else '' }}</td>
                     <td style="color: {{ 'greenyellow' if game.ended_early else 'orangered' }}; font-size: 1.5rem;">{{ "✓" if game.ended_early else "✕" }}</td>
-                    <td style="color: {{ 'greenyellow' if game.ranked else 'orangered' }}; font-size: 1.5rem;">{{ "✓" if game.ranked else "✕" }}</td>
+                    <td class="ranked-column">
+                        <span class="ranked-icon" style="color: {{ 'greenyellow' if game.ranked else 'orangered' }};">{{ "✓" if game.ranked else "✕" }} </span>
+                   <span class="ranked-team-size">{{ game.team1_size }}v{{ game.team2_size }}</span>
+                   <span class="ranked-reason">
+                    {% if game.team1_size != game.team2_size %}
+                        Unbalanced
+                    {% else %}
+                        {{ "Too large" if game.team1_size > 7 }}
+                        {{ "Too small" if game.team1_size < 5 }}
+                    {% endif %}
+                    </span>
+                    </td>
                 </tr>
             {% endfor %}
         </tbody>

--- a/db/sm5.py
+++ b/db/sm5.py
@@ -17,7 +17,7 @@ import sys
 
 # The current version we expect in SM5Game.laserrank_version. If it doesn't match, that game should be recomputed
 # with the recompute_sm5_scores action.
-SM5_LASERRANK_VERSION = 2
+SM5_LASERRANK_VERSION = 3
 
 
 class SM5Game(Model):
@@ -53,6 +53,10 @@ class SM5Game(Model):
     # Our internal SM5 game version when this game was imported. If it doesn't match SM5_LASERRANK_VERSION, it
     # should be recomputed.
     laserrank_version = fields.IntField(default=0)
+    # Number of players on the first team.
+    team1_size = fields.IntField(null=True)
+    # Number of players on the second team.
+    team2_size = fields.IntField(null=True)
 
     def __str__(self) -> str:
         return f"SM5Game ({self.start_time})"

--- a/handlers/admin/recompute_sm5_scores.py
+++ b/handlers/admin/recompute_sm5_scores.py
@@ -1,7 +1,7 @@
 from sanic import Request
 
 from db.sm5 import SM5Game, SM5_LASERRANK_VERSION
-from helpers.sm5helper import update_winner
+from helpers.sm5helper import update_team_sizes, update_winner
 from shared import app
 from utils import admin_only
 
@@ -36,8 +36,11 @@ async def recompute_sm5_scores(request: Request) -> str:
 
 async def _update_games(games: list[SM5Game]) -> int:
     for game in games:
-        if game.laserrank_version < 2:
-            await update_winner(game)
+        if game.laserrank_version < SM5_LASERRANK_VERSION:
+            if game.laserrank_version < 2:
+                await update_winner(game)
+            if game.laserrank_version < 3:
+                await update_team_sizes(game)
         game.laserrank_version = SM5_LASERRANK_VERSION
         await game.save()
 

--- a/helpers/sm5helper.py
+++ b/helpers/sm5helper.py
@@ -676,6 +676,32 @@ async def update_winner(game: SM5Game):
     game.winner_color = winner.value if winner else "none"
 
 
+async def update_team_sizes(game: SM5Game):
+    """Updates the following fields in the game:
+
+    team1_size, team2_size.
+
+    Will not call save() after the update is done.
+    """
+    # Get all teams in the game.
+    teams = await game.teams.all()
+
+    # Remove neutral team(s).
+    teams = [team for team in teams if team.enum != None]
+
+    team1_len = 0
+    team2_len = 0
+
+    if len(teams) > 0:
+        team1_len = await game.entity_ends.filter(entity__team=teams[0], entity__type="player").count()
+
+    if len(teams) > 1:
+        team2_len = await game.entity_ends.filter(entity__team=teams[1], entity__type="player").count()
+
+    game.team1_size = team1_len
+    game.team2_size = team2_len
+
+
 async def get_sm5_last_team_standing(game: SM5Game) -> Optional[Team]:
     """Returns the team that eliminated the other team.
 

--- a/helpers/tdfhelper.py
+++ b/helpers/tdfhelper.py
@@ -350,6 +350,8 @@ async def parse_sm5_game(file_location: str) -> SM5Game:
 
     game.ranked = ranked
     game.ended_early = ended_early
+    game.team1_size = team1_len
+    game.team2_size = team2_len
 
     await game.save()
 


### PR DESCRIPTION
For this, we're now storing the team size in the SM5Game object. There's a new recompute action to retroactively add that to existing objects.

Fixes #125 